### PR TITLE
[🐸 Frogbot] Update version of node-forge to 1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "jquery": "3.4",
         "lodash": "^4.17.0",
         "minimist": "1.2.0",
-        "node-forge": "^0.7.2",
+        "node-forge": "^1.3.0",
         "parse-url": "^6.0.5",
         "undici": "5.8.0",
         "vm2": "^3.9.3"
@@ -606,11 +606,11 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
-      "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.0.tgz",
+      "integrity": "sha512-08ARB91bUi6zNKzVmaj3QO7cr397uiDT2nJ63cHjyNtCTWIgvS47j3eT0WfzUwS9+6Z5YshRaoasFkXCKrIYbA==",
       "engines": {
-        "node": "*"
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/normalize-url": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "gallery_server",
   "version": "1.0.0",
   "description": "",
-  "publishConfig":{"registry":"https://soleng.jfrog.io/artifactory/api/npm/alpha-npm-virtual/"},
+  "publishConfig": {
+    "registry": "https://soleng.jfrog.io/artifactory/api/npm/alpha-npm-virtual/"
+  },
   "main": "app.js",
   "scripts": {
     "test": ""
@@ -18,10 +20,10 @@
     "formidable": "^3.2.3",
     "jquery": "3.4",
     "lodash": "^4.17.0",
-    "node-forge": "^0.7.2",
+    "minimist": "1.2.0",
+    "node-forge": "^1.3.0",
     "parse-url": "^6.0.5",
     "undici": "5.8.0",
-    "vm2": "^3.9.3",
-    "minimist": "1.2.0"
+    "vm2": "^3.9.3"
   }
 }


### PR DESCRIPTION


[comment]: <> (FrogbotReviewComment)

<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>


## 📦 Vulnerable Dependencies

### ✍️ Summary
<div align='center'>

| SEVERITY                | CONTEXTUAL ANALYSIS                  | DIRECT DEPENDENCIES                  | IMPACTED DEPENDENCY                  | FIXED VERSIONS                  | CVES                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: |
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableMediumSeverity.png)<br>  Medium | Not Covered | node-forge:0.7.6 | node-forge 0.7.6 | [1.3.0] | CVE-2022-24773 |

</div>


### 🔬 Research Details


**Description:**
Forge (also called `node-forge`) is a native implementation of Transport Layer Security in JavaScript. Prior to version 1.3.0, RSA PKCS#1 v1.5 signature verification code does not properly check `DigestInfo` for a proper ASN.1 structure. This can lead to successful verification with signatures that contain invalid structures but a valid digest. The issue has been addressed in `node-forge` version 1.3.0. There are currently no known workarounds.


---
<div align='center'>

[🐸 JFrog Frogbot](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>
