### PR TITLE
[🐸 Frogbot] Update version of jquery to 3.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "express": "^4.18.2",
         "express-fileupload": "^1.1.8",
         "formidable": "^3.2.3",
-        "jquery": "3.4",
+        "jquery": "^3.5.0",
         "lodash": "^4.17.0",
         "minimist": "1.2.0",
         "node-forge": "^0.7.2",
@@ -527,9 +527,9 @@
       "integrity": "sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q=="
     },
     "node_modules/jquery": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
+      "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ=="
     },
     "node_modules/lodash": {
       "version": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "gallery_server",
   "version": "1.0.0",
   "description": "",
-  "publishConfig":{"registry":"https://soleng.jfrog.io/artifactory/api/npm/alpha-npm-virtual/"},
+  "publishConfig": {
+    "registry": "https://soleng.jfrog.io/artifactory/api/npm/alpha-npm-virtual/"
+  },
   "main": "app.js",
   "scripts": {
     "test": ""
@@ -16,12 +18,12 @@
     "express": "^4.18.2",
     "express-fileupload": "^1.1.8",
     "formidable": "^3.2.3",
-    "jquery": "3.4",
+    "jquery": "^3.5.0",
     "lodash": "^4.17.0",
+    "minimist": "1.2.0",
     "node-forge": "^0.7.2",
     "parse-url": "^6.0.5",
     "undici": "5.8.0",
-    "vm2": "^3.9.3",
-    "minimist": "1.2.0"
+    "vm2": "^3.9.3"
   }
 }


### PR DESCRIPTION


[comment]: <> (FrogbotReviewComment)

<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>


## 📦 Vulnerable Dependencies

### ✍️ Summary
<div align='center'>

| SEVERITY                | CONTEXTUAL ANALYSIS                  | DIRECT DEPENDENCIES                  | IMPACTED DEPENDENCY                  | FIXED VERSIONS                  | CVES                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: |
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/notApplicableMedium.png)<br>  Medium | Not Applicable | jquery:3.4.1 | jquery 3.4.1 | [3.5.0] | CVE-2020-11022 |

</div>


### 🔬 Research Details


**Description:**
[jQuery](https://jquery.com/) is an open-source JavaScript library meant to make many features of the language easier to use with simplified syntax. Because jQuery is widely imported and used in a large variety of software, its vulnerabilities affect numerous other components.

Attackers can exploit this vulnerability by sending specially crafted HTML inputs for processing by jQuery. If the target component uses jQuery to write or append attacker-controlled input to the HTML it displays (for example, with `.html()`), the attacker can inject malicious JavaScript code for execution, even if the attacker-controlled input is sanitized against XSS. A public [exploit](https://mksben.l0.cm/2020/05/jquery3.5.0-xss.html) exists which demonstrates remote code execution, making this vulnerability likely to be exploited in practice. 

The jQuery HTML-processing functions `.html()`, `.append()`, and others call the `htmlPrefilter()` function, which uses a regular expression to expand some HTML tags with a matching closing tag (for example, adding `</br>` for `<br>`). This has the side effect of taking some HTML attributes outside of their containing elements, so even if they were harmless prior to this transformation (and could pass through most HTML sanitization methods untouched), they could be unsafe after the transformation, resulting in attacker-provided code being injected into the HTML output and then executed. The official [fix](https://github.com/jquery/jquery/commit/1d61fd9407e6fbe82fe55cb0b938307aa0791f77) removes all functionality from the `htmlPrefilter()` function, making it into a no-operation.

This vulnerability was discovered together with [CVE-2020-11023](https://nvd.nist.gov/vuln/detail/CVE-2020-11023), a different vulnerability in `$.htmlPrefilter` method. Both were released as part of this [detailed research](https://mksben.l0.cm/2020/05/jquery3.5.0-xss.html) and fixed in jQuery version 3.5.0 as well. As a best practice to protect and raise the bar against XSS attacks, it is best to sanitize HTML by using a secure third party, such as the open-source [DOMPurify](https://github.com/cure53/DOMPurify).

**Remediation:**
##### Deployment mitigations

Securely sanitize untrusted HTML with [DOMPurify](https://github.com/cure53/DOMPurify)

##### Development mitigations

On jQuery 1.12/2.2 or later, apply this workaround -
```js
jQuery.htmlPrefilter = function( html ) {
	return html;
};
```


---
<div align='center'>

[🐸 JFrog Frogbot](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>
